### PR TITLE
fix: python scanner no permission to artifacts-tmp

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -17,7 +17,6 @@ DOTNET_BUILD_PROJECT=$(plugin_read_config DOTNET_BUILD_PROJECT)
 ENABLE_BRANCH_SCAN=$(plugin_read_config ENABLE_BRANCH_SCAN 'false')
 ENABLE_PULL_REQUEST_SCAN=$(plugin_read_config ENABLE_PULL_REQUEST_SCAN 'false')
 IS_DOTNET=$(plugin_read_config IS_DOTNET 'false')
-LOCAL_ARTIFACTS_DIR="$(mktemp -d "${PWD}/artifacts-tmp.XXXXXXXXXX")"
 PROJECT_KEY=$(plugin_read_config PROJECT_KEY)
 SCAN_ONLY_IF_SOURCES_CHANGED=$(plugin_read_config SCAN_ONLY_IF_SOURCES_CHANGED 'false')
 SONARQUBE_HOST=$(plugin_read_config SONARQUBE_HOST)
@@ -55,6 +54,7 @@ function execute_scanner() {
   docker cp "${PWD}/." "${DOCKERID}:${WORKDIR}"
 
   if [ -n "${ARTIFACT_PATHS[*]}" ]; then
+    LOCAL_ARTIFACTS_DIR="$(mktemp -d "${PWD}/artifacts-tmp.XXXXXXXXXX")"
     for arg in "${ARTIFACT_PATHS[@]}"; do
       echo "Running buildkite-agent artifact download ${arg} ${LOCAL_ARTIFACTS_DIR}"
       buildkite-agent artifact download \


### PR DESCRIPTION
## Summary

sonar-python now fails when searching for coverage reports as it does not have permission to the artifacts-tmp folder.

Only create this folder if using the plugins artifacts